### PR TITLE
Use superagent instead of simple-get

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "tape": "^4.0.0"
   },
   "dependencies": {
-    "simple-get": "^1.4.2",
+    "superagent": "^1.3.0",
     "text-metadata-parser": "^3.0.0"
   }
 }


### PR DESCRIPTION
Since `superagent` parses json, the `parse` transform could be removed, and text-metadata-parser can be run in the cb.

Fixes #8.