### PR TITLE
Add failing test for #10

### DIFF
--- a/test/fakeo_remote_server/dumb-http.js
+++ b/test/fakeo_remote_server/dumb-http.js
@@ -1,0 +1,19 @@
+var url = require('url')
+var fs = require('fs')
+var http = require('http')
+
+module.exports = function(port, dir) {
+	var server = http.createServer(function(req, res) {
+		var file = __dirname + ( dir || '/content') + url.parse(req.url).pathname
+		var stream = fs.createReadStream(file)
+		stream.pipe(res)
+		stream.on('error', function () {
+			res.writeHead(404)
+			res.end('404')
+		})
+	})
+
+	server.listen(port)
+
+	return server
+}

--- a/test/test_retrieve_file.js
+++ b/test/test_retrieve_file.js
@@ -5,6 +5,7 @@ if (process.browser) {
 	tests(require('./fakeo_remote_server/browser-shim.js'), 'http')
 } else {
 	tests(require('./fakeo_remote_server/http.js'), 'http')
+	tests(require('./fakeo_remote_server/dumb-http.js'), 'http')
 	tests(require('./fakeo_remote_server/https.js'), 'https')
 	process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
 }

--- a/test/test_retrieve_index.js
+++ b/test/test_retrieve_index.js
@@ -2,6 +2,7 @@ var test = require('tape')
 var Retrieve = require('../')
 
 tests(require('./fakeo_remote_server/http.js'), 'http')
+tests(require('./fakeo_remote_server/dumb-http.js'), 'http')
 tests(require('./fakeo_remote_server/https.js'), 'https')
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
 


### PR DESCRIPTION
Added a `dumb-http.js` server that does not server `Content-Type` headers.

This causes `test/test_retrieve_index.js` to fail.

See #10.