### PR TITLE
More tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,16 +4,22 @@ var parser = require('text-metadata-parser')
 
 module.exports = function NoddityRetrieval(root) {
 	function lookup(file, property, cb) {
-		var fullUrl = url.resolve(root, file)
-		request.get(fullUrl).end(function (err, res) {
-			if (err) {
-				cb(new Error("Lookup of " + fullUrl + " failed\n========\n" + err.message))
-			} else if (res.status !== 200) {
-				cb(new Error("Lookup of " + fullUrl + " returned status " + res.status + "\n==========\n" + res.text))
-			} else {
-				cb(null, res[property])
-			}
-		})
+		if (typeof file !== 'string') {
+			process.nextTick(function () {
+				cb(new TypeError('Parameter \'file\' must be a string, not ' + typeof file))
+			})
+		} else {
+			var fullUrl = url.resolve(root, file)
+			request.get(fullUrl).end(function (err, res) {
+				if (err) {
+					cb(new Error("Lookup of " + fullUrl + " failed\n========\n" + err.message))
+				} else if (res.status !== 200) {
+					cb(new Error("Lookup of " + fullUrl + " returned status " + res.status + "\n==========\n" + res.text))
+				} else {
+					cb(null, res[property])
+				}
+			})
+		}
 	}
 
 	return {

--- a/test/fakeo_remote_server/https.js
+++ b/test/fakeo_remote_server/https.js
@@ -2,9 +2,9 @@ var url = require('url')
 var send = require('send')
 var selfSignedHttps = require('self-signed-https')
 
-module.exports = function(port) {
+module.exports = function(port, dir) {
 	var server = selfSignedHttps(function(req, res) {
-		send(req, url.parse(req.url).pathname, { root: __dirname + '/content' })
+		send(req, url.parse(req.url).pathname, { root: __dirname + ( dir || '/content') })
 			.pipe(res)
 	})
 

--- a/test/test_retrieve_index.js
+++ b/test/test_retrieve_index.js
@@ -15,7 +15,7 @@ function tests(fakeoServer, protocol) {
 		t.plan(5)
 
 		retrieve.getIndex(function(err, index) {
-			t.equal(index.length, 2)
+			t.equal(index.length, 2, 'index.json has 2 entries')
 
 			retrieve.getPost(index[0], function(err, post) {
 				t.equal(post.metadata.title, 'This is the first post', 'first title is correct')
@@ -30,6 +30,22 @@ function tests(fakeoServer, protocol) {
 				})
 			})
 
+		})
+	})
+
+	test('invalid index', function(t) {
+		var server = fakeoServer(8989, '/content-with-directories/folder1')
+
+		var retrieve = new Retrieve(protocol + '://127.0.0.1:8989')
+
+		t.plan(2)
+
+		retrieve.getIndex(function(err, index) {
+			t.ok(err, 'Error when getting non-existant index')
+			t.equal(index, undefined, 'index defaults to undefined')
+
+			server.close()
+			t.end()
 		})
 	})
 }


### PR DESCRIPTION
- Calls `cb` with a TypeError if `file` is not a string
- Add test for non-existent index.json (Mentioned in #10.)