### PR TITLE
Drop urlencode in favor of encodeurl

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var request = require('superagent')
 var url = require('url')
 var parser = require('text-metadata-parser')
-var urlEncode = require('urlencode')
+var encodeUrl = require('encodeurl')
 
 module.exports = function NoddityRetrieval(root) {
 	function lookup(file, transform, cb) {
@@ -10,7 +10,7 @@ module.exports = function NoddityRetrieval(root) {
 				cb(new TypeError('Parameter \'file\' must be a string, not ' + typeof file))
 			})
 		} else {
-			var encodedFile = file.split('/').map(function (part) { return urlEncode(part) }).join('/')
+			var encodedFile = file.split('/').map(function (part) { return encodeUrl(part) }).join('/')
 			var fullUrl = url.resolve(root, encodedFile)
 
 			request.get(fullUrl).end(function (err, res) {

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "tape": "^4.0.0"
   },
   "dependencies": {
+    "encodeurl": "^1.0.1",
     "superagent": "^1.3.0",
-    "text-metadata-parser": "^3.0.0",
-    "urlencode": "^1.1.0"
+    "text-metadata-parser": "^3.0.0"
   },
   "license": "WTFPL"
 }


### PR DESCRIPTION
`encodeurl` is under pillarjs, so it looks promising, and it doesn't include `iconv-lite`.

Fixes #19.